### PR TITLE
Fix nonce command, dirty fix for correct time calculation

### DIFF
--- a/isSlotLeader.py
+++ b/isSlotLeader.py
@@ -176,7 +176,7 @@ for slot in range(firstSlotOfEpoch, epochLength + firstSlotOfEpoch):
             print("    ,")
         slotcount += 1
         timestamp = datetime.fromtimestamp(slot +
-                                           getGenesisStartEpoch(genesisStart),
+                                           1591566291,
                                            tz=local_tz)
         print("    {")
         print("      \"index\":      " + str(slotcount) + ",")

--- a/runLeaderLogs.sh
+++ b/runLeaderLogs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 SLOTLEADER_CONFIG="slotLeaderLogsConfig.json" # path to configuration file
-EPOCH_NONCE=$(cardano-cli query protocol-state --mainnet | jq -r .chainDepState.csTickn.ticknStateEpochNonce.contents)
+EPOCH_NONCE=$(cardano-cli query protocol-state --mainnet | jq -r .epochNonce.contents)
 
 node cardanoLeaderLogs.js $SLOTLEADER_CONFIG $EPOCH_NONCE


### PR DESCRIPTION
Nonce command needed fixing post HF.
Block slots were not giving correct times for mainnet calculation - hardcoded the fix for now.
To-do: make block slot times work for all networks based on `systemStart` in genesis files.